### PR TITLE
Set MAC address for LAN7800 of RPI3B+

### DIFF
--- a/build/bcm2836/buildbcm2836.sln
+++ b/build/bcm2836/buildbcm2836.sln
@@ -32,6 +32,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "bcm2836sdhc", "..\..\driver
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "bcmauxspi", "..\..\drivers\spi\bcmauxspi\bcmauxspi.vcxproj", "{74219FC7-92D3-4477-A729-A5CEB965B338}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RpiLanPropertyChange", "..\..\drivers\RpiLanPropertyChange\bcm2836\RpiLanPropertyChange.vcxproj", "{AC8330FD-8CB9-4210-9EE0-8B51E972860F}"
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "vchiq", "..\..\drivers\misc\vchiq\vchiq.vcxproj", "{7FED7DE7-D8AE-448B-A7D9-ED99DCDB1F79}"
 	ProjectSection(ProjectDependencies) = postProject
 		{2DF1927E-BBD9-40FD-9658-88C9FB1C9340} = {2DF1927E-BBD9-40FD-9658-88C9FB1C9340}
@@ -92,6 +94,10 @@ Global
 		{78A52003-5B73-4EB4-AA11-C2FC34C6F9CF}.Debug|ARM.Build.0 = Debug|ARM
 		{78A52003-5B73-4EB4-AA11-C2FC34C6F9CF}.Release|ARM.ActiveCfg = Release|ARM
 		{78A52003-5B73-4EB4-AA11-C2FC34C6F9CF}.Release|ARM.Build.0 = Release|ARM
+		{AC8330FD-8CB9-4210-9EE0-8B51E972860F}.Debug|ARM.ActiveCfg = Debug|ARM
+		{AC8330FD-8CB9-4210-9EE0-8B51E972860F}.Debug|ARM.Build.0 = Debug|ARM
+		{AC8330FD-8CB9-4210-9EE0-8B51E972860F}.Release|ARM.ActiveCfg = Release|ARM
+		{AC8330FD-8CB9-4210-9EE0-8B51E972860F}.Release|ARM.Build.0 = Release|ARM
 		{35EBB0B3-001F-45CE-8B60-F50DB4295138}.Debug|ARM.ActiveCfg = Debug|Arm
 		{35EBB0B3-001F-45CE-8B60-F50DB4295138}.Debug|ARM.Build.0 = Debug|Arm
 		{35EBB0B3-001F-45CE-8B60-F50DB4295138}.Release|ARM.ActiveCfg = Release|Arm

--- a/drivers/RpiLanPropertyChange/RpiLanPropertyChange.sln
+++ b/drivers/RpiLanPropertyChange/RpiLanPropertyChange.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.136
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RpiLanPropertyChange", "RpiLanPropertyChange\RpiLanPropertyChange.vcxproj", "{AC8330FD-8CB9-4210-9EE0-8B51E972860F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|arm = Debug|arm
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|arm = Release|arm
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AC8330FD-8CB9-4210-9EE0-8B51E972860F}.Debug|arm.ActiveCfg = Debug|arm
+		{AC8330FD-8CB9-4210-9EE0-8B51E972860F}.Debug|arm.Build.0 = Debug|arm
+		{AC8330FD-8CB9-4210-9EE0-8B51E972860F}.Debug|x64.ActiveCfg = Debug|x64
+		{AC8330FD-8CB9-4210-9EE0-8B51E972860F}.Debug|x64.Build.0 = Debug|x64
+		{AC8330FD-8CB9-4210-9EE0-8B51E972860F}.Debug|x86.ActiveCfg = Debug|Win32
+		{AC8330FD-8CB9-4210-9EE0-8B51E972860F}.Debug|x86.Build.0 = Debug|Win32
+		{AC8330FD-8CB9-4210-9EE0-8B51E972860F}.Release|arm.ActiveCfg = Release|arm
+		{AC8330FD-8CB9-4210-9EE0-8B51E972860F}.Release|arm.Build.0 = Release|arm
+		{AC8330FD-8CB9-4210-9EE0-8B51E972860F}.Release|x64.ActiveCfg = Release|x64
+		{AC8330FD-8CB9-4210-9EE0-8B51E972860F}.Release|x64.Build.0 = Release|x64
+		{AC8330FD-8CB9-4210-9EE0-8B51E972860F}.Release|x86.ActiveCfg = Release|Win32
+		{AC8330FD-8CB9-4210-9EE0-8B51E972860F}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {75211AFC-2FBB-4DC5-83A8-17A6324225C9}
+	EndGlobalSection
+EndGlobal

--- a/drivers/RpiLanPropertyChange/bcm2836/RpiLanPropertyChange.cpp
+++ b/drivers/RpiLanPropertyChange/bcm2836/RpiLanPropertyChange.cpp
@@ -1,0 +1,307 @@
+// RpiLanPropertyChange.cpp : Defines the exported functions for the DLL application.
+//
+
+#include "stdafx.h"
+#include "service.h"
+#include <tchar.h>
+#include <strsafe.h>
+#include <stdio.h>
+
+#include <initguid.h>
+#include <devpkey.h>
+#include <devpropdef.h>
+
+using namespace RpiLanPropertyChange;
+
+//
+// LanDevice creator
+//
+LanDevice::LanDevice() :
+    m_Devinst(0)
+{
+    this->FindDeviceInstance();
+}
+
+LanDevice::~LanDevice()
+{
+    m_Devinst = 0;
+}
+
+//
+// Check and update registry status, restart Lan device
+//
+HRESULT LanDevice::CheckAndUpdateProperty(bool & bUpdateDone)
+{
+    HRESULT hr = S_OK;
+
+    bUpdateDone = true;
+
+    if (!m_Devinst)
+    {
+        hr = HRESULT_FROM_WIN32(CR_INVALID_DEVINST);
+        return hr;
+    }
+
+    LanPropertyChangeStatus LanStatus;
+
+    LanStatus = this->LanPropertyChange();
+
+    switch (LanStatus)
+    {
+    case LanPropertyNoChange:
+        // Start timer to check change if service started before NDIS interface ready
+        // Currently we cannot get this branch
+        // Set update done here
+        bUpdateDone = true;
+        break;
+    case LanPropertyNeedUpdate:
+        this->ApllyLanPropertyChange();
+        this->LanPropertyChangeDone();
+
+        // Fall through
+        // break;        
+    case LanPropertyUpdated:
+        bUpdateDone = true;
+        break;
+    }
+
+    return hr;
+}
+
+//
+// Read Registry value
+//
+LanDevice::LanPropertyChangeStatus LanDevice::LanPropertyChange()
+{
+    LanPropertyChangeStatus LanStatus = LanPropertyUpdated;
+    CONFIGRET cr = CR_SUCCESS;
+    HKEY hKey = 0;
+    WCHAR pSubKey[] = L"PropertyChangeStatus";
+    DWORD type, data, datasize, ret;
+
+    if (!m_Devinst)
+    {
+        LanStatus = LanPropertyNoChange;
+        goto Exit;
+    }
+
+
+    // Open "Software" registry key
+    cr = CM_Open_DevNode_Key(m_Devinst,
+        KEY_QUERY_VALUE,
+        CM_REGISTRY_SOFTWARE,
+        RegDisposition_OpenExisting,
+        &hKey,
+        CM_REGISTRY_SOFTWARE);
+    if (cr != CR_SUCCESS)
+    {
+        LanStatus = LanPropertyNoChange;
+        goto Exit;
+    }
+
+    //  Query value 
+    ret = RegQueryValueEx(hKey, pSubKey, NULL, &type, (BYTE *)&data, &datasize);
+    if (ret == ERROR_FILE_NOT_FOUND)
+    {
+        LanStatus = LanPropertyNoChange;
+        goto Exit;
+    }
+
+    LanStatus = (LanPropertyChangeStatus)data;
+
+Exit:
+    if(hKey)
+    { 
+        RegCloseKey(hKey);
+    }
+
+    return LanStatus;
+}
+
+//
+// Update registry value
+//
+CONFIGRET LanDevice::LanPropertyChangeDone()
+{
+    CONFIGRET cr = CR_SUCCESS;
+    HKEY hKey = 0;
+    WCHAR pSubKey[] = L"PropertyChangeStatus";
+    DWORD data, ret;
+
+    if (!m_Devinst)
+    {
+        cr = CR_NO_SUCH_DEVINST;
+        goto Exit;
+    }
+
+    // Open "Software" registry key
+    cr = CM_Open_DevNode_Key(m_Devinst,
+        KEY_SET_VALUE,
+        CM_REGISTRY_SOFTWARE,
+        RegDisposition_OpenExisting,
+        &hKey,
+        CM_REGISTRY_SOFTWARE);
+    if (cr != CR_SUCCESS)
+    {
+        cr = CR_REGISTRY_ERROR;
+        goto Exit;
+    }
+
+    //  Set value 
+    data = (DWORD)LanPropertyUpdated;
+    ret = RegSetValueEx(hKey, pSubKey, NULL, REG_DWORD, (BYTE *)&data, sizeof(DWORD));
+    if (ret != ERROR_SUCCESS)
+    {
+        cr = CR_REGISTRY_ERROR;
+        goto Exit;
+    }
+
+
+Exit:
+    if (hKey)
+    {
+        RegCloseKey(hKey);
+    }
+
+    return cr;
+}
+
+//
+// Find Lan device
+//
+CONFIGRET LanDevice::FindDeviceInstance()
+{
+    CONFIGRET cr = CR_SUCCESS;
+    PWSTR DeviceList = NULL;
+    ULONG DeviceListLength = 0;
+    PWSTR CurrentDevice;
+    WCHAR DeviceDesc[2048];
+    DEVPROPTYPE PropertyType;
+    DEVINST Devinst;
+    ULONG PropertySize;
+    DWORD Index = 0;
+    WCHAR DescLAN7800[] = L"LAN7800 USB 3.0 to Ethernet 10/100/1000 Adapter";
+
+    cr = CM_Get_Device_ID_List_Size(&DeviceListLength,
+        NULL,
+        CM_GETIDLIST_FILTER_PRESENT);
+
+    if (cr != CR_SUCCESS)
+    {
+        goto Exit;
+    }
+
+    DeviceList = (PWSTR)HeapAlloc(GetProcessHeap(),
+        HEAP_ZERO_MEMORY,
+        DeviceListLength * sizeof(WCHAR));
+
+    if (DeviceList == NULL) {
+        goto Exit;
+    }
+
+    cr = CM_Get_Device_ID_List(NULL,
+        DeviceList,
+        DeviceListLength,
+        CM_GETIDLIST_FILTER_PRESENT);
+
+    if (cr != CR_SUCCESS)
+    {
+        goto Exit;
+    }
+
+    for (CurrentDevice = DeviceList;
+        *CurrentDevice;
+        CurrentDevice += wcslen(CurrentDevice) + 1)
+    {
+        cr = CM_Locate_DevNode(&Devinst,
+            CurrentDevice,
+            CM_LOCATE_DEVNODE_NORMAL);
+
+        if (cr != CR_SUCCESS)
+        {
+            goto Exit;
+        }
+
+        // Query a property on the device. the device description.
+        PropertySize = sizeof(DeviceDesc);
+
+        cr = CM_Get_DevNode_Property(Devinst,
+            &DEVPKEY_Device_DeviceDesc,
+            &PropertyType,
+            (PBYTE)DeviceDesc,
+            &PropertySize,
+            0);
+        if (cr != CR_SUCCESS)
+        {
+            Index++;
+            continue;
+        }
+
+        if (PropertyType != DEVPROP_TYPE_STRING)
+        {
+            Index++;
+            continue;
+        }
+
+        if (_wcsicmp(DescLAN7800, DeviceDesc) == 0)
+        {
+            m_Devinst = Devinst;
+            break;
+        }
+
+        Index++;
+    }
+
+
+Exit:
+    if (DeviceList != NULL)
+    {
+        HeapFree(GetProcessHeap(),
+            0,
+            DeviceList);
+    }
+
+    if (!m_Devinst)
+    {
+        cr = CR_NO_SUCH_DEVINST;
+    }
+
+    return cr;
+}
+
+//
+// Restart Lan device
+//
+CONFIGRET LanDevice::ApllyLanPropertyChange()
+{
+    CONFIGRET cr = CR_SUCCESS;
+
+    if (!m_Devinst)
+    {
+        cr = CR_NO_SUCH_DEVINST;
+        goto Exit;
+    }
+
+    // Restart device
+    cr = CM_Query_And_Remove_SubTree(m_Devinst,
+        NULL,
+        NULL,
+        0,
+        CM_REMOVE_NO_RESTART);
+    if (cr != CR_SUCCESS)
+    {
+        goto Exit;
+    }
+
+    cr = CM_Setup_DevNode(m_Devinst,
+        CM_SETUP_DEVNODE_READY);
+    if (cr != CR_SUCCESS) {
+        goto Exit;
+    }
+
+
+Exit:
+    return cr;
+}
+
+

--- a/drivers/RpiLanPropertyChange/bcm2836/RpiLanPropertyChange.pkg.xml
+++ b/drivers/RpiLanPropertyChange/bcm2836/RpiLanPropertyChange.pkg.xml
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- TODO: Make sure to set the Package attributes -->
+<Package xmlns="urn:Microsoft.WindowsPhone/PackageSchema.v8.00"
+  Owner="$(OEMNAME)"
+  OwnerType="OEM"
+  Platform="$(BSPARCH)"
+  Component="RPi"
+  SubComponent="RpiLanPropertyChange"
+  ReleaseType="Production" >
+
+  <Components>
+    <service
+      description="@%SystemRoot%\system32\RpiLanPropertyChange.dll,-201"
+      displayName="@%SystemRoot%\system32\RpiLanPropertyChange.dll,-200"
+      errorControl="normal"
+      imagePath="%SystemRoot%\system32\svchost.exe -k LocalSystemNetworkRestricted"
+      name="RpiLanPropertyChange"
+      objectName="LocalSystem"
+      requiredPrivileges="SeChangeNotifyPrivilege,SeCreateGlobalPrivilege"
+      sidType="unrestricted"
+      start="auto"
+      subCategory="LocalSystemNetworkRestricted"
+      type="win32UserShareProcess"
+      >
+    <Files>
+      <!-- For kernel mode drivers, $(DRIVER_DEST) evaluates to "drivers" by default -->
+      <!-- For user mode drivers, $(DRIVER_DEST) evaluates to "drivers\umdf" by default -->
+      <File Source="$(_RELEASEDIR)RpiLanPropertyChange.dll" DestinationDir="$(runtime.system32)" />
+    </Files>
+  </Components>
+</Package>

--- a/drivers/RpiLanPropertyChange/bcm2836/RpiLanPropertyChange.vcxproj
+++ b/drivers/RpiLanPropertyChange/bcm2836/RpiLanPropertyChange.vcxproj
@@ -1,0 +1,251 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|arm">
+      <Configuration>Debug</Configuration>
+      <Platform>arm</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|arm">
+      <Configuration>Release</Configuration>
+      <Platform>arm</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{AC8330FD-8CB9-4210-9EE0-8B51E972860F}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>RpiLanPropertyChange</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|arm'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WindowsSDKDesktopARMSupport>true</WindowsSDKDesktopARMSupport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|arm'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <WindowsSDKDesktopARMSupport>true</WindowsSDKDesktopARMSupport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|arm'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|arm'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|arm'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|arm'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;RPILANPROPERTYCHANGE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ModuleDefinitionFile>service.def</ModuleDefinitionFile>
+      <AdditionalDependencies>onecore.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|arm'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;RPILANPROPERTYCHANGE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ModuleDefinitionFile>service.def</ModuleDefinitionFile>
+      <AdditionalDependencies>onecore.lib;kernel32.lib;user32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SetChecksum>true</SetChecksum>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;RPILANPROPERTYCHANGE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ModuleDefinitionFile>service.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;RPILANPROPERTYCHANGE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ModuleDefinitionFile>service.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|arm'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;RPILANPROPERTYCHANGE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ModuleDefinitionFile>service.def</ModuleDefinitionFile>
+      <AdditionalDependencies>onecore.lib;kernel32.lib;user32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SetChecksum>true</SetChecksum>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;RPILANPROPERTYCHANGE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ModuleDefinitionFile>service.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="service.h" />
+    <ClInclude Include="stdafx.h" />
+    <ClInclude Include="targetver.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="dllmain.cpp" />
+    <ClCompile Include="RpiLanPropertyChange.cpp" />
+    <ClCompile Include="service.cpp" />
+    <ClCompile Include="stdafx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|arm'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|arm'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="service.def" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/drivers/RpiLanPropertyChange/bcm2836/dllmain.cpp
+++ b/drivers/RpiLanPropertyChange/bcm2836/dllmain.cpp
@@ -1,0 +1,44 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// dllmain.cpp : Defines the entry point for the DLL application.
+
+#include "stdafx.h"
+
+HINSTANCE g_hInstance = nullptr;
+
+extern "C"
+{
+    // Externally callable functions
+BOOL APIENTRY DllMain( HMODULE hModule,
+                       DWORD  ul_reason_for_call,
+                       LPVOID lpReserved
+                     )
+{
+    switch (ul_reason_for_call)
+    {
+    case DLL_PROCESS_ATTACH:
+    {
+        // Save the dll module handle
+        g_hInstance = hModule;
+
+        // Disable thread-attach calls
+        DisableThreadLibraryCalls(hModule);
+    }
+    break;
+
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+    break;
+
+    case DLL_PROCESS_DETACH:
+    {
+        g_hInstance = NULL;
+    }
+    break;
+    }
+    return TRUE;
+}
+
+} // extern "C"
+

--- a/drivers/RpiLanPropertyChange/bcm2836/service.cpp
+++ b/drivers/RpiLanPropertyChange/bcm2836/service.cpp
@@ -1,0 +1,223 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//
+
+#include "stdafx.h"
+#include "Service.h"
+#include <cstdint>
+#include <thread>
+
+
+using namespace RpiLanPropertyChange;
+
+namespace
+{
+    // 'The service'
+    Service g_service;
+
+    //
+    // Thunk function for RegisterServiceCtrlHandlerEx
+    //
+    DWORD WINAPI ServiceHandlerThunk(DWORD opcode, DWORD eventType, _In_ void* pEventData, _In_ void* pContext)
+    {
+        Service* pThis = reinterpret_cast<Service*>(pContext);
+        return pThis->ServiceHandler(opcode, eventType, pEventData);
+    }
+}
+
+//
+// Service::ctor
+//
+Service::Service() :
+    m_hServiceStatus(nullptr),
+    m_LanDevice(nullptr)
+{
+    ZeroMemory(&m_serviceStatus, sizeof(m_serviceStatus));
+    m_serviceStatus.dwServiceType = SERVICE_WIN32_SHARE_PROCESS;
+}
+
+//
+// Entry point of the service (invoked by sdvhost framework). It works as a Initialize method.
+//
+void Service::ServiceMain(_In_ DWORD /*argc*/, _In_ PTSTR argv[])
+{
+    HRESULT hr = S_OK;
+
+    m_hServiceStatus = ::RegisterServiceCtrlHandlerEx(argv[0], ServiceHandlerThunk, this);
+    if (m_hServiceStatus == nullptr)
+    {
+        hr = HRESULT_FROM_WIN32(::GetLastError()); // Failed to register service control handler
+    }
+
+    if (SUCCEEDED(hr))
+    {
+        hr = UpdateServiceStatus(SERVICE_START_PENDING, NO_ERROR);
+    }
+
+    if (SUCCEEDED(hr))
+    {
+        // Do full initialization of the host on a different Thread
+        // std::thread takes a ref count on the module before starting the thread and releases the
+        // reference on thread exit. Hence we shouldn't worry about module ref counting here and in fact
+        // is unsafe since without the std::thread guarantee, there is no guarantee that the module
+        // is loaded when this method is running. On top of that, calling FreeLibraryAndExitThread()
+        // here will exit the thread and leak the ref count taken by std::thread. Hence keep it simple
+        // and don't bother with module ref count here.
+        std::thread([=]()
+        {
+            Start();
+        }).detach();
+    }
+
+    if (FAILED(hr))
+    {
+        Stop();
+    }
+}
+
+//
+// Performs startup of the service, normally invoked by svchost via ServiceMain()
+//
+void Service::Start()
+{
+    HRESULT hr = S_OK;
+    bool bUpdateDone = false;
+
+    hr = UpdateServiceStatus(SERVICE_RUNNING, NO_ERROR, 0);
+
+    if (!m_LanDevice)
+    {
+        m_LanDevice = new LanDevice;
+    }
+
+    if (m_LanDevice)
+    {
+        hr = m_LanDevice->CheckAndUpdateProperty(bUpdateDone);
+    }
+
+    if (FAILED(hr) || bUpdateDone)
+    {
+        // Signal SCM to stop the NT service
+        Stop();
+    }
+}
+
+//
+// Performs shutdown of the service, normally invoked by svchost via ServiceStopCallback()
+//
+void Service::Stop()
+{
+    if (m_LanDevice)
+    {
+        delete m_LanDevice;
+    }
+
+    (void)UpdateServiceStatus(SERVICE_STOPPED, NO_ERROR, 0);
+
+    // Do not read or write shared variables after the service enters stopped state since
+    // that can race with a new service start and the service DLL may not be unloaded in
+    // all cases (fast service restart, "ServiceDllUnloadOnStop" reg value set to 0, etc.)
+}
+
+
+//
+// Handles system service control requests
+//
+DWORD Service::ServiceHandler(DWORD opcode, DWORD /*eventType*/, _In_ void* /*pEventData*/)
+{
+    DWORD returnStatus = NO_ERROR;
+
+    switch (opcode)
+    {
+    case SERVICE_CONTROL_STOP:
+    case SERVICE_CONTROL_SHUTDOWN:
+    {
+        if (SUCCEEDED(UpdateServiceStatus(SERVICE_STOP_PENDING, NO_ERROR)))
+        {
+            Stop();
+        }
+        else
+        {
+            returnStatus = ::GetLastError();
+        }
+
+    }
+    break;
+
+    case SERVICE_CONTROL_SESSIONCHANGE:
+    {
+        // We currently do not have any workload that is affected by user logon/logoff
+        // consider: load swap database files
+    }
+    break;
+
+    case SERVICE_CONTROL_DEVICEEVENT:
+    {
+        // We currently do not have any workload that is affected by plug n play events
+        // consider: Oasis devices events (would allow a faster statup from callers perspective)
+    }
+    break;
+
+    case SERVICE_CONTROL_POWEREVENT:
+    {
+        // We currently do not have any workload that is affected by power events
+        // consider: timers or offline tasks
+    }
+    break;
+
+    default:
+        break;
+    }
+
+    return returnStatus;
+}
+
+//
+// Updates the state of the service with the system
+//
+HRESULT Service::UpdateServiceStatus(DWORD currentState, DWORD win32ExitCode, DWORD waitHint)
+{
+    HRESULT hr = E_UNEXPECTED;
+
+    if (m_hServiceStatus != nullptr)
+    {
+        hr = S_OK;
+
+        // Do not accept any controls until we are in SERVICE_RUNNING state (i.e., while starting or stopping).
+        // It is a headache to get controls while we are not ready yet and can cause hangs since the control handler
+        // can block on the lock held while we are starting up (for instance) and SCM doesn't expect the control handler
+        // to block (see HandlerEx callback function documentation in MSDN).
+        m_serviceStatus.dwControlsAccepted = (currentState != SERVICE_RUNNING) ? 0 : SERVICE_ACCEPT_STOP;
+        m_serviceStatus.dwControlsAccepted |= SERVICE_ACCEPT_SESSIONCHANGE;
+        m_serviceStatus.dwControlsAccepted |= SERVICE_ACCEPT_POWEREVENT;
+
+        m_serviceStatus.dwCurrentState = currentState;
+        m_serviceStatus.dwWin32ExitCode = win32ExitCode;
+        m_serviceStatus.dwWaitHint = waitHint;
+
+        if ((currentState == SERVICE_RUNNING) ||
+            (currentState == SERVICE_STOPPED))
+        {
+            m_serviceStatus.dwCheckPoint = 0;
+        }
+        else
+        {
+            m_serviceStatus.dwCheckPoint++;
+        }
+
+        // Failed to set the service status, something went wrong.
+        if (!::SetServiceStatus(m_hServiceStatus, &m_serviceStatus))
+        {
+            hr = HRESULT_FROM_WIN32(::GetLastError());
+        }
+    }
+
+    return hr;
+}
+
+// exported functions, called by svchost
+void STDAPICALLTYPE ServiceMain(DWORD argc, _In_ PTSTR argv[])
+{
+    g_service.ServiceMain(argc, argv);
+}
+

--- a/drivers/RpiLanPropertyChange/bcm2836/service.def
+++ b/drivers/RpiLanPropertyChange/bcm2836/service.def
@@ -1,0 +1,3 @@
+LIBRARY
+EXPORTS
+    ServiceMain

--- a/drivers/RpiLanPropertyChange/bcm2836/service.h
+++ b/drivers/RpiLanPropertyChange/bcm2836/service.h
@@ -1,0 +1,58 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//
+
+#pragma once
+
+namespace RpiLanPropertyChange
+{
+
+    class Service final
+    {
+    public:
+        Service();
+
+        void ServiceMain(DWORD argc, _In_ PTSTR argv[]);
+
+        void Start();
+        void Stop();
+        DWORD ServiceHandler(DWORD opcode, DWORD eventType, _In_ void* pEventData);
+
+    private:
+        HRESULT UpdateServiceStatus(DWORD currentState, DWORD win32ExitCode, DWORD waitHint = 10000);
+        SERVICE_STATUS m_serviceStatus;
+        SERVICE_STATUS_HANDLE m_hServiceStatus;
+
+        class LanDevice * m_LanDevice;
+    };
+
+    class LanDevice final
+    {
+    public:
+        LanDevice();
+        ~LanDevice();
+
+        HRESULT CheckAndUpdateProperty(bool & bUpdateDone);
+
+    private:
+        enum LanPropertyChangeStatus
+        {
+            LanPropertyNoChange = 0,
+            LanPropertyNeedUpdate,
+            LanPropertyUpdated
+        };
+
+        DEVINST m_Devinst;
+        CONFIGRET FindDeviceInstance();
+        CONFIGRET ApllyLanPropertyChange();
+        LanPropertyChangeStatus LanPropertyChange();
+        CONFIGRET LanPropertyChangeDone();
+    };
+}
+
+extern "C"
+{
+    // public callable by svchost
+    void STDAPICALLTYPE ServiceMain(DWORD argc, _In_ PTSTR argv[]);
+} // extern "C"
+

--- a/drivers/RpiLanPropertyChange/bcm2836/stdafx.cpp
+++ b/drivers/RpiLanPropertyChange/bcm2836/stdafx.cpp
@@ -1,0 +1,1 @@
+#include "stdafx.h"

--- a/drivers/RpiLanPropertyChange/bcm2836/stdafx.h
+++ b/drivers/RpiLanPropertyChange/bcm2836/stdafx.h
@@ -1,0 +1,15 @@
+// stdafx.h : include file for standard system include files,
+// or project specific include files that are used frequently, but
+// are changed infrequently
+//
+
+#pragma once
+
+#include "targetver.h"
+
+#define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
+// Windows Header Files
+#include <windows.h>
+#include <cfgmgr32.h>
+
+// reference additional headers your program requires here

--- a/drivers/RpiLanPropertyChange/bcm2836/targetver.h
+++ b/drivers/RpiLanPropertyChange/bcm2836/targetver.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// Including SDKDDKVer.h defines the highest available Windows platform.
+
+// If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
+// set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
+
+#include <SDKDDKVer.h>

--- a/drivers/mailbox/bcm2836/device.c
+++ b/drivers/mailbox/bcm2836/device.c
@@ -430,6 +430,190 @@ Return Value:
     NTSTATUS value
 
 --*/
+
+extern WCHAR macAddrStrGlobal[13];
+
+NTSTATUS RpiqSetNdisMacAddress()
+{
+    NTSTATUS status = STATUS_SUCCESS;
+    UNICODE_STRING KeyPrefix = RTL_CONSTANT_STRING (
+        L"\\Registry\\Machine\\System\\CurrentControlSet\\Control\\Class\\{4d36e972-e325-11ce-bfc1-08002be10318}\\");
+    UNICODE_STRING DriverDesc = RTL_CONSTANT_STRING ( L"DriverDesc" );
+    UNICODE_STRING Desc;
+    UNICODE_STRING DescLAN7800 = RTL_CONSTANT_STRING ( L"LAN7800" );
+    UNICODE_STRING NetworkAddress = RTL_CONSTANT_STRING ( L"NetworkAddress" );
+    UNICODE_STRING PropertyChangeStatus = RTL_CONSTANT_STRING ( L"PropertyChangeStatus" );
+    UNICODE_STRING KeyName;
+    WCHAR KeyInstance[] = L"0000";
+    ULONG Instance = 0;
+    static BOOLEAN MacSet = 0;
+    OBJECT_ATTRIBUTES ObjectAttributes;  
+    HANDLE BaseKey = NULL;
+    HANDLE SubKey = NULL;
+    PKEY_VALUE_FULL_INFORMATION infoBuffer = NULL;
+    ULONG infoBufferLength = 0;
+    ULONG RequireBufferLength = 0;
+    DWORD value;
+
+    if(MacSet) {
+    return status;
+        }
+
+    MacSet = TRUE;
+
+    InitializeObjectAttributes (&ObjectAttributes,
+                                (PUNICODE_STRING)&KeyPrefix,
+                                OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE,
+                                NULL,
+                                NULL
+                                );
+
+    status = ZwOpenKey (&BaseKey,
+                        KEY_READ | KEY_WRITE,
+                        &ObjectAttributes);
+    if (!NT_SUCCESS(status)){
+        BaseKey = NULL;
+        goto End;
+    }
+    
+    KeyName.Length = 8;
+    KeyName.MaximumLength = 8;
+    KeyName.Buffer = KeyInstance;
+
+    while(STATUS_OBJECT_NAME_NOT_FOUND != status)
+    {
+        status = RtlStringCchPrintfW(KeyInstance,
+                                     sizeof(KeyInstance) / sizeof(WCHAR),
+                                     L"%04d",
+                                     Instance);
+        Instance ++;
+        
+        if (!NT_SUCCESS(status)){
+            // continue to try next entry
+            continue;
+        }
+
+        InitializeObjectAttributes (&ObjectAttributes,
+                                    (PUNICODE_STRING)&KeyName,
+                                    OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE,
+                                    BaseKey,
+                                    NULL
+                                    );
+
+        status = ZwOpenKey (&SubKey,
+                            KEY_READ | KEY_WRITE,
+                            &ObjectAttributes);
+        if (!NT_SUCCESS(status)){
+            SubKey = NULL;
+            // continue to try next entry
+            continue;
+        }
+
+        if ( infoBuffer ) {
+            RtlZeroMemory  (infoBuffer, infoBufferLength);
+        } 
+
+        status = ZwQueryValueKey(
+                            SubKey,
+                            &DriverDesc,
+                            KeyValueFullInformation,
+                            infoBuffer,
+                            infoBufferLength,
+                            &RequireBufferLength
+                            );
+
+        if ( status == STATUS_BUFFER_TOO_SMALL ) {
+            infoBuffer = ExAllocatePool(
+                                NonPagedPoolNx,
+                                RequireBufferLength
+                                );
+
+            if ( infoBuffer == NULL ) {
+                goto End;
+            }
+
+            infoBufferLength = RequireBufferLength;
+
+            status = ZwQueryValueKey(
+                                SubKey,
+                                &DriverDesc,
+                                KeyValueFullInformation,
+                                infoBuffer,
+                                infoBufferLength,
+                                &RequireBufferLength
+                                );
+                    
+        }
+
+        // Query Success
+        if ( status == STATUS_SUCCESS ) {
+            Desc.Length = (USHORT)infoBuffer->DataLength;
+            Desc.MaximumLength = (USHORT)infoBuffer->DataLength;
+            Desc.Buffer = (PWSTR)((PCHAR)infoBuffer +
+                                          infoBuffer->DataOffset);
+
+            if(RtlPrefixUnicodeString (&DescLAN7800, &Desc, TRUE) == TRUE) {
+                status = ZwQueryValueKey(
+                                SubKey,
+                                &PropertyChangeStatus,
+                                KeyValueFullInformation,
+                                infoBuffer,
+                                infoBufferLength,
+                                &RequireBufferLength
+                                );
+                                
+                if(STATUS_OBJECT_NAME_NOT_FOUND == status) {
+                    //Network Mac Address is not set
+                    status = ZwSetValueKey(SubKey,
+                                   &NetworkAddress,
+                                   0, // title index; must be zero.
+                                   REG_SZ,
+                                   &macAddrStrGlobal,
+                                   sizeof(macAddrStrGlobal));
+                    //Require Property change    
+                    value = 1;                
+                    status = ZwSetValueKey(SubKey,
+                                   &PropertyChangeStatus,
+                                   0, // title index; must be zero.
+                                   REG_DWORD,
+                                   (PVOID)&value,
+                                   sizeof(DWORD));
+                }
+                 // Finished Setting MAC or it already set before, exit no matter status
+                 goto End;
+            }
+        }
+
+        if(STATUS_OBJECT_NAME_NOT_FOUND == status) {
+            // ignore non existence for value key
+            status = STATUS_SUCCESS;
+        }
+
+        if(SubKey) {
+            // Close this sub key before query next
+            ZwClose(SubKey);
+            SubKey = NULL;
+        }
+        if ( infoBuffer ) {
+            ExFreePool (infoBuffer);
+            infoBuffer = NULL;
+            infoBufferLength = 0;
+        }
+    }
+
+End:
+    if(BaseKey) {
+        ZwClose(BaseKey);
+    }
+    if(SubKey) {
+        ZwClose(SubKey);
+    }
+    if ( infoBuffer ) {
+        ExFreePool (infoBuffer);
+    }
+    return status;
+}
+
 _Use_decl_annotations_
 NTSTATUS RpiqNdisInterfaceCallback (
     VOID* NotificationStructure,
@@ -457,6 +641,8 @@ NTSTATUS RpiqNdisInterfaceCallback (
             RPIQ_LOG_ERROR("Fail to create remote target %!STATUS!", status);
             goto End;
         }
+
+        RpiqSetNdisMacAddress();
 
         WDF_OBJECT_ATTRIBUTES_INIT(&ioTargetAttrib);
         ioTargetAttrib.ParentObject = device;

--- a/drivers/mailbox/bcm2836/init.c
+++ b/drivers/mailbox/bcm2836/init.c
@@ -211,6 +211,20 @@ NTSTATUS RpiSetDeviceMacAddress (
         RPIQ_LOG_ERROR(
             "Failed to set MAC value at NetworkAddress registry %!STATUS!",
             status);
+        //goto End;
+    }
+	
+	status = RtlWriteRegistryValue(
+        RTL_REGISTRY_CONTROL,
+        L"\\Class\\{4d36e972-e325-11ce-bfc1-08002be10318}\\0001",
+        L"NetworkAddress",
+        REG_SZ,
+        &macAddrStr,
+        sizeof(macAddrStr));
+    if (!NT_SUCCESS(status)) {
+        RPIQ_LOG_ERROR(
+            "Failed to set MAC value at NetworkAddress registry %!STATUS!",
+            status);
         goto End;
     }
 

--- a/drivers/mailbox/bcm2836/init.c
+++ b/drivers/mailbox/bcm2836/init.c
@@ -102,6 +102,9 @@ Return Value:
     NTSTATUS value
 
 --*/
+
+WCHAR macAddrStrGlobal[13] = { 0 };
+
 _Use_decl_annotations_
 NTSTATUS RpiSetDeviceMacAddress (
     DEVICE_CONTEXT* DeviceContextPtr
@@ -194,6 +197,23 @@ NTSTATUS RpiSetDeviceMacAddress (
     if (!NT_SUCCESS(status)) {
         RPIQ_LOG_ERROR(
             "Failed to print MAC address %!STATUS!",
+            status);
+        goto End;
+    }
+
+    status = RtlStringCchPrintfW(
+        macAddrStrGlobal,
+        ARRAYSIZE(macAddrStrGlobal),
+        L"%02X%02X%02X%02X%02X%02X",
+        macAddrProperty->MACAddress[0],
+        macAddrProperty->MACAddress[1],
+        macAddrProperty->MACAddress[2],
+        macAddrProperty->MACAddress[3],
+        macAddrProperty->MACAddress[4],
+        macAddrProperty->MACAddress[5]);
+    if (!NT_SUCCESS(status)) {
+        RPIQ_LOG_ERROR(
+            "Failed to print MAC address global %!STATUS!",
             status);
         goto End;
     }

--- a/drivers/mailbox/bcm2836/init.c
+++ b/drivers/mailbox/bcm2836/init.c
@@ -211,20 +211,6 @@ NTSTATUS RpiSetDeviceMacAddress (
         RPIQ_LOG_ERROR(
             "Failed to set MAC value at NetworkAddress registry %!STATUS!",
             status);
-        //goto End;
-    }
-	
-	status = RtlWriteRegistryValue(
-        RTL_REGISTRY_CONTROL,
-        L"\\Class\\{4d36e972-e325-11ce-bfc1-08002be10318}\\0003",
-        L"NetworkAddress",
-        REG_SZ,
-        &macAddrStr,
-        sizeof(macAddrStr));
-    if (!NT_SUCCESS(status)) {
-        RPIQ_LOG_ERROR(
-            "Failed to set MAC value at NetworkAddress registry %!STATUS!",
-            status);
         goto End;
     }
 

--- a/drivers/mailbox/bcm2836/init.c
+++ b/drivers/mailbox/bcm2836/init.c
@@ -211,6 +211,20 @@ NTSTATUS RpiSetDeviceMacAddress (
         RPIQ_LOG_ERROR(
             "Failed to set MAC value at NetworkAddress registry %!STATUS!",
             status);
+        //goto End;
+    }
+	
+	    status = RtlWriteRegistryValue(
+        RTL_REGISTRY_CONTROL,
+        L"\\Class\\{4d36e972-e325-11ce-bfc1-08002be10318}\\0003",
+        L"NetworkAddress",
+        REG_SZ,
+        &macAddrStr,
+        sizeof(macAddrStr));
+    if (!NT_SUCCESS(status)) {
+        RPIQ_LOG_ERROR(
+            "Failed to set MAC value at NetworkAddress registry %!STATUS!",
+            status);
         goto End;
     }
 

--- a/drivers/mailbox/bcm2836/init.c
+++ b/drivers/mailbox/bcm2836/init.c
@@ -211,20 +211,6 @@ NTSTATUS RpiSetDeviceMacAddress (
         RPIQ_LOG_ERROR(
             "Failed to set MAC value at NetworkAddress registry %!STATUS!",
             status);
-        //goto End;
-    }
-	
-	    status = RtlWriteRegistryValue(
-        RTL_REGISTRY_CONTROL,
-        L"\\Class\\{4d36e972-e325-11ce-bfc1-08002be10318}\\0003",
-        L"NetworkAddress",
-        REG_SZ,
-        &macAddrStr,
-        sizeof(macAddrStr));
-    if (!NT_SUCCESS(status)) {
-        RPIQ_LOG_ERROR(
-            "Failed to set MAC value at NetworkAddress registry %!STATUS!",
-            status);
         goto End;
     }
 

--- a/drivers/mailbox/bcm2836/init.c
+++ b/drivers/mailbox/bcm2836/init.c
@@ -216,7 +216,7 @@ NTSTATUS RpiSetDeviceMacAddress (
 	
 	status = RtlWriteRegistryValue(
         RTL_REGISTRY_CONTROL,
-        L"\\Class\\{4d36e972-e325-11ce-bfc1-08002be10318}\\0001",
+        L"\\Class\\{4d36e972-e325-11ce-bfc1-08002be10318}\\0003",
         L"NetworkAddress",
         REG_SZ,
         &macAddrStr,

--- a/drivers/sd/bcm2836/rpisdhc/rpisdhc.cpp
+++ b/drivers/sd/bcm2836/rpisdhc/rpisdhc.cpp
@@ -1371,15 +1371,12 @@ NTSTATUS SDHC::sendCommandInternal (
             // Clear all ERROR mask set and return Success
             // Temp clear error flags for read/write test command
             //
-            if(((Cmd.Fields.Command == 0x1) && (hsts.Fields.Crc7Error))) //||
-                //(Cmd.Fields.Command == 0xe) ||
-                //(Cmd.Fields.Command == 0x13))
+            if((Cmd.Fields.Command == 0x1) && (hsts.Fields.Crc7Error))
                {
                 //
                 // CMD1 alwary return CRC7 error on EMMC device
                 // Clear all ERROR mask set and return Success
                 //
-                //hsts.AsUint32 |= _HSTS::UINT32_CRC7_ERROR_MASK;
                 this->writeRegisterNoFence(hsts);
                 SDHC_LOG_ERROR(
                     "Ignore CRC7 error for CMD1");

--- a/drivers/sd/bcm2836/rpisdhc/rpisdhc.cpp
+++ b/drivers/sd/bcm2836/rpisdhc/rpisdhc.cpp
@@ -844,6 +844,7 @@ NTSTATUS SDHC::sdhcIssueBusOperation (
         ULONG(BusOperationPtr->Type));
 
     NTSTATUS status;
+	_HCFG hcfg{ 0 };
 
     switch (BusOperationPtr->Type) {
     case SdResetHost:
@@ -872,7 +873,6 @@ NTSTATUS SDHC::sdhcIssueBusOperation (
 
     case SdResetHw:
     case SdSetVoltage:
-    case SdSetBusWidth:
     case SdSetBusSpeed:
     case SdSetSignalingVoltage:
     case SdSetDriveStrength:
@@ -885,6 +885,16 @@ NTSTATUS SDHC::sdhcIssueBusOperation (
             ULONG(BusOperationPtr->Type));
         return STATUS_SUCCESS;
 
+	case SdSetBusWidth:	
+		thisPtr->readRegisterNoFence(&hcfg);
+		if((BusOperationPtr->Parameters.BusWidth == SdBusWidth8Bit) || (BusOperationPtr->Parameters.BusWidth == SdBusWidth4Bit)) {
+			hcfg.Fields.WideExtBus = 1;
+		}
+		if(BusOperationPtr->Parameters.BusWidth == SdBusWidth1Bit) {
+			hcfg.Fields.WideExtBus = 0;
+		}		
+		thisPtr->writeRegisterNoFence(hcfg);
+		return STATUS_SUCCESS;
     default:
         SDHC_LOG_ASSERTION(
             "Ignored request for unsupported bus operation. (BusOperationPtr->Type = %lu)",
@@ -1076,6 +1086,9 @@ NTSTATUS SDHC::resetHost (
         edm.Fields.ReadThreshold = 4;
         edm.Fields.WriteThreshold = 4;
         this->writeRegisterNoFence(edm);
+		_HBCT hbct{ 0 };
+		hbct.Fields.ByteCount = 512;
+		this->writeRegisterNoFence(hbct);
 
         status = STATUS_SUCCESS;
         break;
@@ -1348,12 +1361,37 @@ NTSTATUS SDHC::sendCommandInternal (
 
         status = this->getLastCommandCompletionStatus();
         if (!NT_SUCCESS(status)) {
+			//
+			// Need to read status register again to get real error code
+			//
+			_HSTS hsts{ 0 };
+			this->readRegisterNoFence(&hsts);
+			// 
+			// CMD1 alwary return CRC7 error on EMMC device
+			// Clear all ERROR mask set and return Success
+			// Temp clear error flags for read/write test command
+			//	
+			if(((Cmd.Fields.Command == 0x1) && (hsts.Fields.Crc7Error))) //||
+			  //(Cmd.Fields.Command == 0xe) ||
+			  //(Cmd.Fields.Command == 0x13))
+			   {
+				// 
+				// CMD1 alwary return CRC7 error on EMMC device
+				// Clear all ERROR mask set and return Success
+				//				
+				//hsts.AsUint32 |= _HSTS::UINT32_CRC7_ERROR_MASK;
+				this->writeRegisterNoFence(hsts);
+				SDHC_LOG_ERROR(
+					"Ignore CRC7 error for CMD1");
+				return STATUS_SUCCESS;
+			} else {	
             this->updateAllRegistersDump();
             SDHC_LOG_ERROR(
                 "Device command failed. (cmd.Fields.Command = 0x%lx, status = %!STATUS!)",
                 ULONG(Cmd.Fields.Command),
                 status);
             return status;
+			}
         } // if
     } // if
 

--- a/drivers/sd/bcm2836/rpisdhc/rpisdhc.cpp
+++ b/drivers/sd/bcm2836/rpisdhc/rpisdhc.cpp
@@ -844,7 +844,7 @@ NTSTATUS SDHC::sdhcIssueBusOperation (
         ULONG(BusOperationPtr->Type));
 
     NTSTATUS status;
-	_HCFG hcfg{ 0 };
+    _HCFG hcfg{ 0 };
 
     switch (BusOperationPtr->Type) {
     case SdResetHost:
@@ -885,16 +885,16 @@ NTSTATUS SDHC::sdhcIssueBusOperation (
             ULONG(BusOperationPtr->Type));
         return STATUS_SUCCESS;
 
-	case SdSetBusWidth:	
-		thisPtr->readRegisterNoFence(&hcfg);
-		if((BusOperationPtr->Parameters.BusWidth == SdBusWidth8Bit) || (BusOperationPtr->Parameters.BusWidth == SdBusWidth4Bit)) {
-			hcfg.Fields.WideExtBus = 1;
-		}
-		if(BusOperationPtr->Parameters.BusWidth == SdBusWidth1Bit) {
-			hcfg.Fields.WideExtBus = 0;
-		}		
-		thisPtr->writeRegisterNoFence(hcfg);
-		return STATUS_SUCCESS;
+    case SdSetBusWidth:
+        thisPtr->readRegisterNoFence(&hcfg);
+        if((BusOperationPtr->Parameters.BusWidth == SdBusWidth8Bit) || (BusOperationPtr->Parameters.BusWidth == SdBusWidth4Bit)) {
+            hcfg.Fields.WideExtBus = 1;
+        }
+        if(BusOperationPtr->Parameters.BusWidth == SdBusWidth1Bit) {
+            hcfg.Fields.WideExtBus = 0;
+        }
+        thisPtr->writeRegisterNoFence(hcfg);
+        return STATUS_SUCCESS;
     default:
         SDHC_LOG_ASSERTION(
             "Ignored request for unsupported bus operation. (BusOperationPtr->Type = %lu)",
@@ -1086,9 +1086,9 @@ NTSTATUS SDHC::resetHost (
         edm.Fields.ReadThreshold = 4;
         edm.Fields.WriteThreshold = 4;
         this->writeRegisterNoFence(edm);
-		_HBCT hbct{ 0 };
-		hbct.Fields.ByteCount = 512;
-		this->writeRegisterNoFence(hbct);
+        _HBCT hbct{ 0 };
+        hbct.Fields.ByteCount = 512;
+        this->writeRegisterNoFence(hbct);
 
         status = STATUS_SUCCESS;
         break;
@@ -1361,37 +1361,37 @@ NTSTATUS SDHC::sendCommandInternal (
 
         status = this->getLastCommandCompletionStatus();
         if (!NT_SUCCESS(status)) {
-			//
-			// Need to read status register again to get real error code
-			//
-			_HSTS hsts{ 0 };
-			this->readRegisterNoFence(&hsts);
-			// 
-			// CMD1 alwary return CRC7 error on EMMC device
-			// Clear all ERROR mask set and return Success
-			// Temp clear error flags for read/write test command
-			//	
-			if(((Cmd.Fields.Command == 0x1) && (hsts.Fields.Crc7Error))) //||
-			  //(Cmd.Fields.Command == 0xe) ||
-			  //(Cmd.Fields.Command == 0x13))
-			   {
-				// 
-				// CMD1 alwary return CRC7 error on EMMC device
-				// Clear all ERROR mask set and return Success
-				//				
-				//hsts.AsUint32 |= _HSTS::UINT32_CRC7_ERROR_MASK;
-				this->writeRegisterNoFence(hsts);
-				SDHC_LOG_ERROR(
-					"Ignore CRC7 error for CMD1");
-				return STATUS_SUCCESS;
-			} else {	
+            //
+            // Need to read status register again to get real error code
+            //
+            _HSTS hsts{ 0 };
+            this->readRegisterNoFence(&hsts);
+            //
+            // CMD1 alwary return CRC7 error on EMMC device
+            // Clear all ERROR mask set and return Success
+            // Temp clear error flags for read/write test command
+            //
+            if(((Cmd.Fields.Command == 0x1) && (hsts.Fields.Crc7Error))) //||
+                //(Cmd.Fields.Command == 0xe) ||
+                //(Cmd.Fields.Command == 0x13))
+               {
+                //
+                // CMD1 alwary return CRC7 error on EMMC device
+                // Clear all ERROR mask set and return Success
+                //
+                //hsts.AsUint32 |= _HSTS::UINT32_CRC7_ERROR_MASK;
+                this->writeRegisterNoFence(hsts);
+                SDHC_LOG_ERROR(
+                    "Ignore CRC7 error for CMD1");
+                return STATUS_SUCCESS;
+            } else {
             this->updateAllRegistersDump();
             SDHC_LOG_ERROR(
                 "Device command failed. (cmd.Fields.Command = 0x%lx, status = %!STATUS!)",
                 ULONG(Cmd.Fields.Command),
                 status);
             return status;
-			}
+            }
         } // if
     } // if
 


### PR DESCRIPTION
In mailbox, queries and savesMAC address for LAN. When NDIS interface notification received, sets this MAC address in NetworkAddress in NDIS software key if the flag registry LanPropertyChange is not set.
During system boot, a service thread RpiLanPropertyChange is started and checks the flag RpiLanPropertyChange. If new MAC address is to be applied (RpiLanPropertyChange == 1), then restarts Lan7800, and sets flag RpiLanPropertyChange to 2.

Test results:
 [Testcase.xlsx](https://github.com/ms-iot/rpi-iotcore/files/3012629/Testcase.xlsx)
