### PR TITLE
Fix naming to RPi to be consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,6 @@ We provide a `binexport.ps1` script to scrape the BSP components together into a
     .\binexport.ps1 C:\Release -IsDebug # for debug binaries
     ```
 4. The script will generate a zip file **RPi_BSP_xx.zip** that can be imported into the IoT-ADK-Addonkit shell using [Import-IoTBSP](https://github.com/ms-iot/iot-adk-addonkit/blob/master/Tools/IoTCoreImaging/Docs/Import-IoTBSP.md).
-
+    ```powershell
+    Import-IoTBSP RPi C:\Temp\RPi_BSP_xx.zip
+    ```

--- a/bspfiles/OEMInputSamples/RetailOEMInput.xml
+++ b/bspfiles/OEMInputSamples/RetailOEMInput.xml
@@ -3,12 +3,12 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
   xmlns="http://schemas.microsoft.com/embedded/2004/10/ImageUpdate">
-  <Description>Contoso Windows 10 IoT Core Retail FFU with RPi2 BSP</Description>
-  <SOC>RPi2-R</SOC>
-  <!-- For no recovery support, use SOC: RPi2 -->
+  <Description>Contoso Windows 10 IoT Core Retail FFU with RPi BSP</Description>
+  <SOC>RPi-R</SOC>
+  <!-- For no recovery support, use SOC: RPi -->
   <SV>RASPBERRY PI</SV>
-  <Device>RPi2-R</Device>
-  <!-- For no recovery support, use Device: RPi2 -->
+  <Device>RPi-R</Device>
+  <!-- For no recovery support, use Device: RPi -->
   <ReleaseType>Production</ReleaseType>
   <BuildType>fre</BuildType>
   <SupportedLanguages>
@@ -29,7 +29,7 @@
   </Resolutions>
   <AdditionalFMs>
     <!-- Including BSP feature manifest -->
-    <AdditionalFM>%BLD_DIR%\MergedFMs\RPi2FM.xml</AdditionalFM>
+    <AdditionalFM>%BLD_DIR%\MergedFMs\RPiFM.xml</AdditionalFM>
     <!-- Including OEM feature manifest -->
     <AdditionalFM>%BLD_DIR%\MergedFMs\OEMCommonFM.xml</AdditionalFM>
     <AdditionalFM>%BLD_DIR%\MergedFMs\OEMFM.xml</AdditionalFM>

--- a/bspfiles/OEMInputSamples/TestOEMInput.xml
+++ b/bspfiles/OEMInputSamples/TestOEMInput.xml
@@ -3,12 +3,12 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
   xmlns="http://schemas.microsoft.com/embedded/2004/10/ImageUpdate">
-  <Description>Contoso Windows 10 IoT Core Test FFU with RPi2 BSP</Description>
-  <SOC>RPi2-R</SOC>
-  <!-- For no recovery support, use SOC: RPi2 -->
+  <Description>Contoso Windows 10 IoT Core Test FFU with RPi BSP</Description>
+  <SOC>RPi-R</SOC>
+  <!-- For no recovery support, use SOC: RPi -->
   <SV>RASPBERRY PI</SV>
-  <Device>RPi2-R</Device>
-  <!-- For no recovery support, use Device: RPi2 -->
+  <Device>RPi-R</Device>
+  <!-- For no recovery support, use Device: RPi -->
   <ReleaseType>Test</ReleaseType>
   <BuildType>fre</BuildType>
   <SupportedLanguages>
@@ -29,7 +29,7 @@
   </Resolutions>
   <AdditionalFMs>
     <!-- Including BSP feature manifest -->
-    <AdditionalFM>%BLD_DIR%\MergedFMs\RPi2FM.xml</AdditionalFM>
+    <AdditionalFM>%BLD_DIR%\MergedFMs\RPiFM.xml</AdditionalFM>
     <!-- Including OEM feature manifest -->
     <AdditionalFM>%BLD_DIR%\MergedFMs\OEMCommonFM.xml</AdditionalFM>
     <AdditionalFM>%BLD_DIR%\MergedFMs\OEMFM.xml</AdditionalFM>

--- a/bspfiles/Packages/RPiFM.xml
+++ b/bspfiles/Packages/RPiFM.xml
@@ -24,15 +24,15 @@
   </BasePackages>
   <DeviceLayoutPackages>
     <!-- MBR 4GB layout  -->
-    <PackageFile SOC="RPi2" Path="%PKGBLD_DIR%" Name="%OEM_NAME%.DeviceLayout.MBR4GB.cab"/>
+    <PackageFile SOC="RPi" Path="%PKGBLD_DIR%" Name="%OEM_NAME%.DeviceLayout.MBR4GB.cab"/>
     <!-- MBR 8GB layout - select this by specifying the SOC field in the OEMInput xml file -->
-    <PackageFile SOC="RPi2-R" Path="%PKGBLD_DIR%" Name="%OEM_NAME%.DeviceLayout.MBR8GB-R.cab"/>
+    <PackageFile SOC="RPi-R" Path="%PKGBLD_DIR%" Name="%OEM_NAME%.DeviceLayout.MBR8GB-R.cab"/>
   </DeviceLayoutPackages>
   <OEMDevicePlatformPackages>
     <!-- MBR 4GB layout  -->
-    <PackageFile Device="RPi2" Path="%PKGBLD_DIR%" Name="%OEM_NAME%.DeviceLayout.MBR4GB.cab"/>
+    <PackageFile Device="RPi" Path="%PKGBLD_DIR%" Name="%OEM_NAME%.DeviceLayout.MBR4GB.cab"/>
     <!-- MBR 8GB layout - select this by specifying the SOC field in the OEMInput xml file -->
-    <PackageFile Device="RPi2-R" Path="%PKGBLD_DIR%" Name="%OEM_NAME%.DeviceLayout.MBR8GB-R.cab"/>
+    <PackageFile Device="RPi-R" Path="%PKGBLD_DIR%" Name="%OEM_NAME%.DeviceLayout.MBR8GB-R.cab"/>
   </OEMDevicePlatformPackages>
   
   <Features>

--- a/bspfiles/Packages/RPiFMFileList.xml
+++ b/bspfiles/Packages/RPiFMFileList.xml
@@ -2,7 +2,7 @@
 <FMCollectionManifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemas.microsoft.com/embedded/2004/10/ImageUpdate" Product="IoTUAP" >
   <IsBuildFeatureEnabled>true</IsBuildFeatureEnabled>
   <FMs>
-    <FM ID="RPi2" Path="$(FMDirectory)\RPi2FM.xml" ReleaseType="Production" OwnerName="OEM_NAME" OwnerType="OEM" CPUType="ARM" Critical="true"/>
+    <FM ID="RPi" Path="$(FMDirectory)\RPiFM.xml" ReleaseType="Production" OwnerName="OEM_NAME" OwnerType="OEM" CPUType="ARM" Critical="true"/>
  </FMs>
 
   <SupportedResolutions>

--- a/tools/binexport.ps1
+++ b/tools/binexport.ps1
@@ -45,7 +45,9 @@ Copy-Item -Path "$RootDir\bspfiles\*" -Destination "$OutputDir\RPi\" -Recurse -F
 Copy-Item -Path "$bindir\*" -Destination "$OutputDir\RPi\Packages\RPi.Drivers\" -Include "*.sys","*.dll","*.inf" -Force | Out-Null
 
 Write-Host "Output File: $OutputFile"
-
+if (Test-Path "$OutputDir\$OutputFile" -PathType Leaf){
+    Remove-Item "$OutputDir\$OutputFile" -Force | Out-Null
+}
 Compress-Archive -Path "$OutputDir\RPi\" -CompressionLevel "Fastest" -DestinationPath "$OutputDir\$OutputFile"
 Remove-Item "$OutputDir\RPi\" -Recurse -Force | Out-Null
 


### PR DESCRIPTION
Fix the prefix to be RPi across the files to be consistent.  This enables the following cmd to work
**Import-IoTBSP RPi C:\RPi_BSP_Release.zip**