### PR TITLE
Minor compile issues fixed.

### DIFF
--- a/drivers/audio/bcm2836/adapter.cpp
+++ b/drivers/audio/bcm2836/adapter.cpp
@@ -20,7 +20,7 @@ Abstract:
 #include <rpiwav.h>
 
 #include "simple.h"
-#include "minipairs.h"
+#include "rpiwav/minipairs.h"
 
 
 typedef void (*fnPcDriverUnload) (PDRIVER_OBJECT);

--- a/drivers/spi/bcmauxspi/bcmauxspi.cpp
+++ b/drivers/spi/bcmauxspi/bcmauxspi.cpp
@@ -19,6 +19,9 @@
 #include "bcmauxspi-hw.h"
 #include "bcmauxspi.h"
 
+// Ignore usage of the macro - based offsetof pattern in constant expressions is non - standard
+#pragma warning(disable:4644)
+
 namespace { // static
 
     WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(AUXSPI_DEVICE, GetDeviceContext);


### PR DESCRIPTION
Fixed the wrong path to minipairs.h.

Disabled warning 4644 which is new recommendation. It has to be disabled since all warnings are treated as errors.